### PR TITLE
Automatic Docker Builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/386,linux/amd64
           push: true
           tags: |
             ghcr.io/boramalper/stupid-computer:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,36 @@
+name: Docker CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/386,linux/amd64
+          push: true
+          tags: |
+            ghcr.io/boramalper/stupid-computer:latest
+      -
+        name: Image digest
+        run:  echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM haskell:8.10-buster
+
+RUN apt-get update && apt-get install alex happy
+RUN cabal update
+
+WORKDIR /app
+
+COPY Setup.hs              .
+COPY stupid-computer.cabal .
+COPY CHANGELOG.md          .
+COPY LICENSE               .
+COPY src/                  ./src/
+
+RUN ls
+RUN cabal install --only-dependencies
+RUN cabal build


### PR DESCRIPTION
A PR to enable automatic Docker builds using GitHub Actions. 

- One issue is that currently builds take around 13 minutes so pushing often might cause problems.
- I would explore static compilation such that you can "simply" extract the compiled binary from docker images and distribute them separately.

Try it out:

```bash
cd stupid-computer  # repo root
docker run -v $(pwd):/app/orig:ro -it ghcr.io/boramalper/stupid-computer:latest /bin/bash
```

and then

```
root@63a1f5e45f87:/app# ./dist-newstyle/build/x86_64-linux/ghc-8.10.2/stupid-computer-0.1.4.0/x/stupid-computer/build/stupid-computer/stupid-computer orig/examples/listcomp.hs
      doublelarge [2, 4, 5]
   =  [x * 2 | x <- [2, 4, 5], x > 3]
   =  [2 * 2 | 2 > 3] ++ [4 * 2 | 4 > 3] ++ [5 * 2 | 5 > 3]
   =  [] ++ [4 * 2 | 4 > 3] ++ [5 * 2 | 5 > 3]
   =  [] ++ [4 * 2] ++ [5 * 2 | 5 > 3]
   =  [] ++ [4 * 2] ++ [5 * 2]
   =  [] ++ [8] ++ [5 * 2]
   =  [] ++ [8,10]
   =  [8,10]
```

----

Don't forget to 

1. Create `CR_PAT` secret (a personal access token [PAT] with container read/write/delete access)

   https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets

2. Make your container image public

   https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/configuring-access-control-and-visibility-for-container-images

----

Feel free to reach me out if you have any questions. =)